### PR TITLE
fix correct open new film modal

### DIFF
--- a/src/js/film.js/film-modal-window.js
+++ b/src/js/film.js/film-modal-window.js
@@ -26,6 +26,7 @@ function onCloseModal() {
   window.removeEventListener('keydown', onEscKeyPress);
   refs.backdrop.classList.add('is-hidden');
   document.body.classList.remove('no-scroll');
+  refs.filmModal.innerHTML = '';
 }
 
 function onBackdropClick(event) {

--- a/src/sass/components/film-modal-window.scss
+++ b/src/sass/components/film-modal-window.scss
@@ -155,7 +155,7 @@
 
 .content-text {
   flex: 1;
-  color: var(--grey-color);
+  color: var(--grey-text-color);
   font-weight: 500;
   font-size: 12px;
   line-height: 1.33;


### PR DESCRIPTION
добавила очистку модального окна после закрытия  refs.filmModal.innerHTML = ''; чтобы при открытии модалки нового фильма не подгружалась на секунду инфо о предыдущем 